### PR TITLE
Remove request insurance checks from default registry

### DIFF
--- a/publishable/service-health-checking.php
+++ b/publishable/service-health-checking.php
@@ -6,8 +6,6 @@ return [
         \Cego\ServiceHealthChecking\ServiceHealthConfigCheck::class,
         \Cego\ServiceHealthChecking\DefaultDatabaseConnectionCheck::class,
         \Cego\ServiceHealthChecking\CacheCheck::class,
-        \Cego\ServiceHealthChecking\FailedRequestInsurancesCheck::class,
-        \Cego\ServiceHealthChecking\ActiveRequestInsurancesCheck::class,
     ],
     // Define the thresholds for request insurance health levels
     'request-insurance' => [


### PR DESCRIPTION
RI checks cause false positives in Nagios monitoring and are not critical to service health. The check classes are kept for projects that explicitly opt in.